### PR TITLE
Slaveidfix

### DIFF
--- a/framertu.go
+++ b/framertu.go
@@ -33,7 +33,6 @@ func NewRTUFrame(packet []byte) (*RTUFrame, error) {
 		Function: uint8(packet[1]),
 		Data:     packet[2 : pLen-2],
 	}
-
 	return frame, nil
 }
 
@@ -60,6 +59,11 @@ func (frame *RTUFrame) Bytes() []byte {
 	binary.LittleEndian.PutUint16(bytes[pLen:pLen+2], crc)
 
 	return bytes
+}
+
+// GetFunction returns the Modbus function code.
+func (frame *RTUFrame) GetAddress() uint8 {
+	return frame.Address
 }
 
 // GetFunction returns the Modbus function code.

--- a/servertu.go
+++ b/servertu.go
@@ -9,17 +9,17 @@ import (
 
 // ListenRTU starts the Modbus server listening to a serial device.
 // For example:  err := s.ListenRTU(&serial.Config{Address: "/dev/ttyUSB0"})
-func (s *Server) ListenRTU(serialConfig *serial.Config) (err error) {
+func (s *Server) ListenRTU(serialConfig *serial.Config, slaveId uint8) (err error) {
 	port, err := serial.Open(serialConfig)
 	if err != nil {
 		log.Fatalf("failed to open %s: %v\n", serialConfig.Address, err)
 	}
 	s.ports = append(s.ports, port)
-	go s.acceptSerialRequests(port)
+	go s.acceptSerialRequests(port, slaveId)
 	return err
 }
 
-func (s *Server) acceptSerialRequests(port serial.Port) {
+func (s *Server) acceptSerialRequests(port serial.Port, slaveId uint8) {
 	for {
 		buffer := make([]byte, 512)
 
@@ -41,10 +41,14 @@ func (s *Server) acceptSerialRequests(port serial.Port) {
 				log.Printf("bad serial frame error %v\n", err)
 				return
 			}
+			if frame.GetAddress() == slaveId {
+				request := &Request{port, frame}
+				s.requestChan <- request
+			} else {
+				log.Printf("wrong slave address")
+			}
 
-			request := &Request{port, frame}
-
-			s.requestChan <- request
+			
 		}
 	}
 }

--- a/servertu.go
+++ b/servertu.go
@@ -9,17 +9,17 @@ import (
 
 // ListenRTU starts the Modbus server listening to a serial device.
 // For example:  err := s.ListenRTU(&serial.Config{Address: "/dev/ttyUSB0"})
-func (s *Server) ListenRTU(serialConfig *serial.Config, slaveId uint8) (err error) {
+func (s *Server) ListenRTU(serialConfig *serial.Config, deviceId uint8) (err error) {
 	port, err := serial.Open(serialConfig)
 	if err != nil {
 		log.Fatalf("failed to open %s: %v\n", serialConfig.Address, err)
 	}
 	s.ports = append(s.ports, port)
-	go s.acceptSerialRequests(port, slaveId)
+	go s.acceptSerialRequests(port, deviceId)
 	return err
 }
 
-func (s *Server) acceptSerialRequests(port serial.Port, slaveId uint8) {
+func (s *Server) acceptSerialRequests(port serial.Port, deviceId uint8) {
 	for {
 		buffer := make([]byte, 512)
 
@@ -41,7 +41,7 @@ func (s *Server) acceptSerialRequests(port serial.Port, slaveId uint8) {
 				log.Printf("bad serial frame error %v\n", err)
 				return
 			}
-			if frame.GetAddress() == slaveId {
+			if frame.GetAddress() == deviceId {
 				request := &Request{port, frame}
 				s.requestChan <- request
 			} else {


### PR DESCRIPTION
In order to be able to use the library with several Modbus slaves, it is necessary to set a device ID. This was added. To call the function ListenRTU it is now necessary to specify a device ID.