### PR TITLE
Keep RTU server running

### DIFF
--- a/servertu.go
+++ b/servertu.go
@@ -20,6 +20,7 @@ func (s *Server) ListenRTU(serialConfig *serial.Config) (err error) {
 }
 
 func (s *Server) acceptSerialRequests(port serial.Port) {
+	SkipFrameError:
 	for {
 		buffer := make([]byte, 512)
 
@@ -39,7 +40,11 @@ func (s *Server) acceptSerialRequests(port serial.Port) {
 			frame, err := NewRTUFrame(packet)
 			if err != nil {
 				log.Printf("bad serial frame error %v\n", err)
-				return
+				//The next line prevents RTU server from exiting when it receives a bad frame. Simply discard the erroneous 
+				//frame and wait for next frame by jumping back to the beginning of the 'for' loop.
+				log.Printf("Keep the RTU server running!!\n")
+				continue SkipFrameError
+				//return
 			}
 
 			request := &Request{port, frame}


### PR DESCRIPTION
Sometimes the bus may receive incomplete or bad RTU Frames which cause the listening loop to exit. This is not ideal especially for remote devices. Simply jump back to the top of the loop and wait for the next frame. This discards the bad frame and awaits for the next frame, ensuring RTU-server runs without terminating or processing bad frames.