### PR TITLE
feat: support accepting TCP connections through net.Listener

### DIFF
--- a/servetcp.go
+++ b/servetcp.go
@@ -48,6 +48,11 @@ func (s *Server) accept(listen net.Listener) error {
 	}
 }
 
+func (s *Server) ListenWithListener(listen net.Listener) {
+	s.listeners = append(s.listeners, listen)
+	go s.accept(listen)
+}
+
 // ListenTCP starts the Modbus server listening on "address:port".
 func (s *Server) ListenTCP(addressPort string) (err error) {
 	listen, err := net.Listen("tcp", addressPort)
@@ -55,8 +60,7 @@ func (s *Server) ListenTCP(addressPort string) (err error) {
 		log.Printf("Failed to Listen: %v\n", err)
 		return err
 	}
-	s.listeners = append(s.listeners, listen)
-	go s.accept(listen)
+	s.ListenWithListener(listen)
 	return err
 }
 
@@ -67,7 +71,6 @@ func (s *Server) ListenTLS(addressPort string, config *tls.Config) (err error) {
 		log.Printf("Failed to Listen on TLS: %v\n", err)
 		return err
 	}
-	s.listeners = append(s.listeners, listen)
-	go s.accept(listen)
+	s.ListenWithListener(listen)
 	return err
 }


### PR DESCRIPTION
This allows the user to specify a listener with port 0, which has the OS assign a free port automatically. They can then use the listener to get the assigned port. This isn't possible without having a reference to the listener.