### PR TITLE
avoid ListenRTU to stop accepting requests because of timeouts. add an option to notify of error if acceptSerialRequests exits.

### DIFF
--- a/servertu.go
+++ b/servertu.go
@@ -22,7 +22,7 @@ func (s *Server) ListenRTU(serialConfig *serial.Config) (err error) {
 		defer func(){
 			s.portsWG.Done()
 			// TODO notify caller of ListenRTU we stop accepting requests for this serialConfig, possibliy by sending sth to a channel passed to ListenRTU
-		}
+		}()
 		s.acceptSerialRequests(port)
 	}()
 

--- a/servertu.go
+++ b/servertu.go
@@ -4,13 +4,30 @@ import (
 	"errors"
 	"io"
 	"log"
+	"syscall"
+	"time"
 
 	"github.com/goburrow/serial"
 )
 
+type ListenRTUOption func(options *rtuOptions)
+type rtuOptions struct {
+	notifyExit chan error
+}
+
+func NotifyExit(ch chan error) ListenRTUOption {
+	return func(s *rtuOptions) {
+		s.notifyExit = ch
+	}
+}
+
 // ListenRTU starts the Modbus server listening to a serial device.
 // For example:  err := s.ListenRTU(&serial.Config{Address: "/dev/ttyUSB0"})
-func (s *Server) ListenRTU(serialConfig *serial.Config) (err error) {
+func (s *Server) ListenRTU(serialConfig *serial.Config, options ...ListenRTUOption) (err error) {
+	var opts rtuOptions
+	for _, option := range options {
+		option(&opts)
+	}
 	port, err := serial.Open(serialConfig)
 	if err != nil {
 		log.Fatalf("failed to open %s: %v\n", serialConfig.Address, err)
@@ -19,38 +36,40 @@ func (s *Server) ListenRTU(serialConfig *serial.Config) (err error) {
 
 	s.portsWG.Add(1)
 	go func() {
-		defer func(){
-			s.portsWG.Done()
-			// TODO notify caller of ListenRTU we stop accepting requests for this serialConfig, possibliy by sending sth to a channel passed to ListenRTU
-		}()
-		s.acceptSerialRequests(port)
+		defer s.portsWG.Done()
+		err := s.acceptSerialRequests(port)
+		if opts.notifyExit != nil {
+			opts.notifyExit <- err
+		}
 	}()
 
 	return err
 }
 
-func (s *Server) acceptSerialRequests(port serial.Port) {
-	SkipFrameError:
+func (s *Server) acceptSerialRequests(port serial.Port) error {
+SkipFrameError:
 	for {
 		select {
 		case <-s.portsCloseChan:
-			return
+			return nil
 		default:
 		}
 
 		buffer := make([]byte, 512)
 
 		bytesRead, err := port.Read(buffer)
-		
-		// dont exit loop for a timeout reading request
 		if errors.Is(err, serial.ErrTimeout) {
 			continue
 		}
 		if err != nil {
+			if errors.Is(err, serial.ErrTimeout) || errors.Is(err, syscall.EWOULDBLOCK) {
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
 			if err != io.EOF {
 				log.Printf("serial read error %v\n", err)
 			}
-			return
+			return err
 		}
 
 		if bytesRead != 0 {


### PR DESCRIPTION
- avoid ListenRTU to stop accepting requests because of timeouts. 
- add an option to notify of error if acceptSerialRequests exits, so ListenRTU caller can retry